### PR TITLE
implement code and tests to check for for 4xx and 5xx server responses

### DIFF
--- a/test/ajax.test.js
+++ b/test/ajax.test.js
@@ -98,6 +98,51 @@ describe('Ajax', function() {
 
             expect(fn).to.throw(Error)
         });
+
+        it('Should throw an error upon server response 4xx', function(done) {
+
+            var data = {
+                "id": "a3aad38e-55db-4c59-bb82-d98b38fc2b83",
+                "name": "John Smith",
+                "email": "test_user@relayr.io"
+            };
+
+            var dataJson = JSON.stringify(data);
+            var config = {
+                url: "/oauth-userinfo",
+                type: "GET",
+                isObject: true,
+            }
+
+            expect(ajaxInstance._xhrRequest(config, null)).to.eventually.be.rejected.notify(done);
+            this.requests[0].respond(404, {});
+        });
+
+        it('Should throw an error upon server response 5xx', function(done) {
+
+            var data = {
+                "id": "a3aad38e-55db-4c59-bb82-d98b38fc2b83",
+                "name": "John Smith",
+                "email": "test_user@relayr.io"
+            };
+
+            var dataJson = JSON.stringify(data);
+            var config = {
+                url: "/oauth-userinfo",
+                type: "GET",
+                isObject: true,
+            }
+
+            expect(ajaxInstance._xhrRequest(config, null)).to.eventually.be.rejected.notify(done);
+            this.requests[0].respond(500, {});
+        });
+
+
+
+
+
+
+
     });
 
 

--- a/tools/ajax.js
+++ b/tools/ajax.js
@@ -102,6 +102,7 @@ default class Ajax {
             xhrObject.onreadystatechange = function() {
                 if (xhrObject.readyState === 4) {
                     if (xhrObject.status > 199 && xhrObject.status < 299) {
+                        //2xx success
                         if (options.isObject) {
 
                             resolve(JSON.parse(xhrObject.responseText));
@@ -109,9 +110,13 @@ default class Ajax {
 
                             resolve(xhrObject.responseText);
                         }
-                    }
-                    if (xhrObject.status > 399 && xhrObject.status < 600) {
-
+                    } else if (xhrObject.status > 399 && xhrObject.status < 499) {
+                        //4xx client error
+                        console.log('there seems to be a problem on the client side');
+                        reject(xhrObject);
+                    } else if (xhrObject.status > 499) {
+                        //5xx server error
+                        console.log('there seems to be a problem on the server side');
                         reject(xhrObject);
                     }
                 }


### PR DESCRIPTION
right now it has console.logs to communicate which server response you got... maybe there is a better way or maybe we don't need it at all, but throwing errors stopped the promise from resolving. 