### PR TITLE
Fix error handling on Device.connect

### DIFF
--- a/dist/src/entities/Device.js
+++ b/dist/src/entities/Device.js
@@ -227,6 +227,8 @@
                 return new Promise(function (resolve, reject) {
                     getChannel.then(subscribeMqtt).then(function () {
                         resolve(connection);
+                    }).catch(function (error) {
+                        return reject(error);
                     });
                 });
             }

--- a/src/entities/Device.js
+++ b/src/entities/Device.js
@@ -156,7 +156,7 @@ default class Device {
         return new Promise((resolve, reject) => {
             getChannel.then(subscribeMqtt).then(function() {
                 resolve(connection);
-            });
+            }).catch(error => reject(error));
         });
     }
 


### PR DESCRIPTION
If a Device failed to get a channel or connect to the MQTT broker, then the error would be squashed and un-recoverable.

